### PR TITLE
Add outs in Linescore model

### DIFF
--- a/src/MLBClient.cs
+++ b/src/MLBClient.cs
@@ -21,6 +21,7 @@ namespace BaseballSharp
     {
         private static HttpClient _httpClient = new HttpClient();
         private static readonly string _baseUrl = "https://statsapi.mlb.com/api/v1";
+        private static readonly short _outsInCompletedInning = 3;
 
         private async Task<string> GetResponseAsync(string endpoint)
         {
@@ -197,6 +198,10 @@ namespace BaseballSharp
                 {
                     CurrentInning = lineScoresJson?.currentInning,
                     InningHalf = lineScoresJson?.inningHalf,
+                    // If it's the last inning, use outs from the dto.  Otherwise, use the number 
+                    // of outs in an inning.  In the v1 api, "outs" at the root is the current number
+                    // of outs in the current inning; it should not be extrapolated to all innings.
+                    Outs = inning?.num == lineScoresJson?.currentInning ? lineScoresJson?.outs : _outsInCompletedInning,
                     ScheduledInnings = lineScoresJson?.scheduledInnings,
                     HometeamRuns = lineScoresJson?.teams?.home?.runs,
                     HometeamHits = lineScoresJson?.teams?.home?.hits,

--- a/src/Models/Linescore.cs
+++ b/src/Models/Linescore.cs
@@ -13,7 +13,12 @@ public class Linescore
     public string? InningHalf { get; set; }
 
     /// <summary>
-    /// The number of innings scheduled for the game..
+    /// The number of outs in this half of the inning.
+    /// </summary>
+    public int? Outs { get; set; }
+
+    /// <summary>
+    /// The number of innings scheduled for the game.
     /// </summary>
     public int? ScheduledInnings { get; set; }
 


### PR DESCRIPTION
I'm working on a fun side project, and having the number of outs in each Linescore would help me with some business logic --  specifically, whether the game is done.  Without knowing the number of outs in the last (and current) inning, it's challenging to know whether the inning is ongoing or completed.

The api has a somewhat odd structure in that `outs` are not associated with each inning; it is only on the outer layer.  So in the code, we _assume_ that every inning before the current one has had 3 outs.  Knowing baseball well, I think this is a reasonable invariant!

I ensured that `outs` is being propagated as expected using the sample program for a current inning.
<img width="491" alt="InningNumber Cint  4 m" src="https://github.com/markjamesm/BaseballSharp/assets/8618763/382bbacf-6b6a-4232-8459-cd8dd6724903">

I also ensured that `outs` is being propagated as expected using an inning _before_ the current inning.
<img width="461" alt="OffensiveTeamPitcherName  string  null" src="https://github.com/markjamesm/BaseballSharp/assets/8618763/3e097542-c0f0-42c3-a3b1-99d94ed958e6">