### PR TITLE
Add StatusCode to understand where we are in the game

### DIFF
--- a/src/Enums/StatusCode.cs
+++ b/src/Enums/StatusCode.cs
@@ -1,0 +1,13 @@
+﻿namespace BaseballSharp.Enums;
+/// <summary>
+/// Represents the status of the game using predefined status codes.  Note that there may be more codes than these -- 
+/// these are the status codes observed manually.
+/// </summary>
+public enum GameStatus
+{
+    Final,      // "F"
+    InProgress, // "I"
+    Delayed,    // "IR"
+    PreGame,    // "P"
+    Scheduled   // "S"
+}

--- a/src/MLBClient.cs
+++ b/src/MLBClient.cs
@@ -51,7 +51,8 @@ namespace BaseballSharp
                         gameID = game.gamePk,
                         AwayTeam = game.teams?.away?.team?.name,
                         HomeTeam = game.teams?.home?.team?.name,
-                        ScheduledInnings = game.scheduledInnings
+                        ScheduledInnings = game.scheduledInnings,
+                        StatusCode = game.status?.statusCode
                     });
                 }
             }

--- a/src/MLBClient.cs
+++ b/src/MLBClient.cs
@@ -52,7 +52,7 @@ namespace BaseballSharp
                         AwayTeam = game.teams?.away?.team?.name,
                         HomeTeam = game.teams?.home?.team?.name,
                         ScheduledInnings = game.scheduledInnings,
-                        StatusCode = game.status?.statusCode
+                        StatusCode = Schedule.GetStatusCode(game.status?.statusCode)
                     });
                 }
             }

--- a/src/Models/Schedule.cs
+++ b/src/Models/Schedule.cs
@@ -17,7 +17,7 @@ public class Schedule
     public int? ScheduledInnings { get; set; }
 
     /// <summary>
-    /// The status of the game.  Some possible codes are "F" for Final, "I" for In Progress, 
+    /// The status of the game.  A few possible codes are "F" for Final, "I" for In Progress, 
     /// "IR" for Delayed, "P" for Pre-game, and "S" for Sceduled.
     /// </summary>
     public string? StatusCode { get; set; }

--- a/src/Models/Schedule.cs
+++ b/src/Models/Schedule.cs
@@ -1,4 +1,6 @@
-﻿namespace BaseballSharp.Models;
+﻿using BaseballSharp.Enums;
+
+namespace BaseballSharp.Models;
 
 public class Schedule
 {
@@ -20,5 +22,23 @@ public class Schedule
     /// The status of the game.  A few possible codes are "F" for Final, "I" for In Progress, 
     /// "IR" for Delayed, "P" for Pre-game, and "S" for Sceduled.
     /// </summary>
-    public string? StatusCode { get; set; }
+    public GameStatus? StatusCode { get; set; }
+
+    /// <summary>
+    /// Gets the GameStatus enum value based on the provided status code string.
+    /// </summary>
+    /// <param name="statusCode">The status code string.</param>
+    /// <returns>The corresponding GameStatus enum value, or null if the status code is unknown.</returns>
+    public static GameStatus? GetStatusCode(string? statusCode)
+    {
+        return statusCode switch
+        {
+            "F" => GameStatus.Final,
+            "I" => GameStatus.InProgress,
+            "IR" => GameStatus.Delayed,
+            "P" => GameStatus.PreGame,
+            "S" => GameStatus.Scheduled,
+            _ => null,
+        };
+    }
 }

--- a/src/Models/Schedule.cs
+++ b/src/Models/Schedule.cs
@@ -15,4 +15,10 @@ public class Schedule
     /// The number of innings scheduled for the game. 
     /// </summary>
     public int? ScheduledInnings { get; set; }
+
+    /// <summary>
+    /// The status of the game.  Some possible codes are "F" for Final, "I" for In Progress, 
+    /// "IR" for Delayed, "P" for Pre-game, and "S" for Sceduled.
+    /// </summary>
+    public string? StatusCode { get; set; }
 }


### PR DESCRIPTION
Add "StatusCode" to the `Schedule` model, piping in data we already get in the Schedule DTO.  I'd like to use it in my project downstream.

I also add a `GameStatus` enum.  Unfortunately, I don't have access to the MLB documentation, so I'm not quite sure if I'm capturing all potential game statuses -- I feel like I at least captured most of them.  If we see an unfamiliar status, I just return null.

I thought about calling "StatusCode" "GameStatusCode", but I figured that it is clear enough we are already in the "Game" context.

Tested with the console app:
<img width="413" alt="Count = 15" src="https://github.com/markjamesm/BaseballSharp/assets/8618763/a8fffc13-19a9-4581-81c8-46cdebe96da9">
<img width="402" alt="Ballpark  string  null" src="https://github.com/markjamesm/BaseballSharp/assets/8618763/ad55304c-64e5-4147-9256-d130e00786dd">

